### PR TITLE
Updating to qt 6.2.5

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -115,18 +115,20 @@ jobs:
       GCS_SVC_ACCT: ${{ secrets.GCS_SVC_ACCT }}
       GCS_UPLOAD_DIR: 'gs://files.jacktrip.org/contrib/qt'
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        if: needs.preflight.outputs.upload_artifact == 'true' || matrix.qt-type == 'static'
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
       - name: Linux - install dependencies
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && (needs.preflight.outputs.upload_artifact == 'true' || matrix.qt-type == 'static')
         run: |
           sudo apt-get update
-          sudo apt-get install --yes libclang-dev libclang-11-dev llvm-11-dev ninja-build
+          sudo apt-get install --yes libclang-dev libclang-11-dev llvm-11-dev libclang-12-dev llvm-12-dev ninja-build
           sudo apt-get install --yes libfreetype6-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libdrm-dev libglu1-mesa-dev libwayland-dev libwayland-egl1-mesa libgles2-mesa-dev libwayland-server0 libwayland-egl-backend-dev libxcb1-dev libxext-dev libfontconfig1-dev libxrender-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev '^libxcb.*-dev' libxcb-render-util0-dev libxcomposite-dev libgtk-3-dev
       - name: OSX - install dependencies
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && (needs.preflight.outputs.upload_artifact == 'true' || matrix.qt-type == 'static')
         env:
           HOMEBREW_NO_ANALYTICS: 1
           HOMEBREW_NO_AUTO_UPDATE: 1
@@ -137,16 +139,16 @@ jobs:
             sudo xcode-select -s ${{ matrix.xcode-directory }}
           fi
       - name: Windows - install dependencies
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && (needs.preflight.outputs.upload_artifact == 'true' || matrix.qt-type == 'static')
         shell: bash
         run: |
           choco install pkgconfiglite winflexbison3 gperf nodejs-lts python2 python3 nasm StrawberryPerl --no-progress
           echo "c:\Program Files\NASM" >> $GITHUB_PATH
       - name: Windows - setup MSVC
         uses: ilammy/msvc-dev-cmd@v1
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && (needs.preflight.outputs.upload_artifact == 'true' || matrix.qt-type == 'static')
       - name: Unix - build Qt from source
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && (needs.preflight.outputs.upload_artifact == 'true' || matrix.qt-type == 'static')
         env:
           QT_BUILD_ARCH: ${{ matrix.qt-arch }}
         run: |
@@ -154,7 +156,7 @@ jobs:
           mkdir -p /opt/qtbuild
           if [[ "${{ matrix.qt-type }}" == "dynamic" ]]; then ./qtbuild.sh -dynamic ${{ matrix.qt-version }}; else ./qtbuild.sh ${{ matrix.qt-version }}; fi
       - name: Windows - build Qt from source
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && (needs.preflight.outputs.upload_artifact == 'true' || matrix.qt-type == 'static')
         env:
           QT_BUILD_ARCH: ${{ matrix.qt-arch }}
         run: |
@@ -164,6 +166,7 @@ jobs:
           cd c:\qt\build
           if ( "${{ matrix.qt-type }}" -eq "dynamic" ) { c:\qt\build\qtbuild.bat -dynamic ${{ matrix.qt-version }} } else { c:\qt\build\qtbuild.bat ${{ matrix.qt-version }} }
       - name: Compress the build directory
+        if: needs.preflight.outputs.upload_artifact == 'true' || matrix.qt-type == 'static'
         shell: bash
         id: create-binary
         run: |
@@ -182,6 +185,7 @@ jobs:
           echo "filename=$BINFILE" >> $GITHUB_OUTPUT
           echo "ext=$EXT" >> $GITHUB_OUTPUT
       - name: Upload build artifact to GitHub
+        if: needs.preflight.outputs.upload_artifact == 'true'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.name }}
@@ -194,6 +198,7 @@ jobs:
           service_account: ${{ env.GCS_SVC_ACCT }}
           create_credentials_file: true
       - name: Setup SDK for GCS
+        if: needs.preflight.outputs.upload_artifact == 'true'
         uses: 'google-github-actions/setup-gcloud@v1'
         with:
           version: '>= 363.0.0'

--- a/README.md
+++ b/README.md
@@ -10,46 +10,34 @@ Projects that use these artifacts must adhere to the terms & conditions of the [
 ## Download Links
 
 Mac OS X (Universal)
-* [Qt 6.2.4 Static](https://files.jacktrip.org/contrib/qt/qt-6.2.4-static-osx.tar.gz)
-* [Qt 6.2.4 Dynamic](https://files.jacktrip.org/contrib/qt/qt-6.2.4-dynamic-osx.tar.gz)
+* [Qt 6.2.5 Static](https://files.jacktrip.org/contrib/qt/qt-6.2.5-static-osx.tar.gz)
+* [Qt 6.2.5 Dynamic](https://files.jacktrip.org/contrib/qt/qt-6.2.5-dynamic-osx.tar.gz)
 * [Qt 5.15.10 Static](https://files.jacktrip.org/contrib/qt/qt-5.15.10-static-osx.tar.gz)
 * [Qt 5.15.10 Dynamic](https://files.jacktrip.org/contrib/qt/qt-5.15.10-dynamic-osx.tar.gz)
 
 Windows MSVC (64-bit)
-* [Qt 6.2.4 Static](https://files.jacktrip.org/contrib/qt/qt-6.2.4-static-win.zip)
-* [Qt 6.2.4 Dynamic](https://files.jacktrip.org/contrib/qt/qt-6.2.4-dynamic-win.zip)
+* [Qt 6.2.5 Static](https://files.jacktrip.org/contrib/qt/qt-6.2.5-static-win.zip)
+* [Qt 6.2.5 Dynamic](https://files.jacktrip.org/contrib/qt/qt-6.2.5-dynamic-win.zip)
 * [Qt 5.15.10 Static](https://files.jacktrip.org/contrib/qt/qt-5.15.10-static-win.zip)
 * [Qt 5.15.10 Dynamic](https://files.jacktrip.org/contrib/qt/qt-5.15.10-dynamic-win.zip)
 
 Linux (64-bit)
-* [Qt 6.2.4 Static](https://files.jacktrip.org/contrib/qt/qt-6.2.4-static-linux.tar.gz)
+* [Qt 6.2.5 Static](https://files.jacktrip.org/contrib/qt/qt-6.2.5-static-linux.tar.gz)
 * [Qt 5.15.10 Static](https://files.jacktrip.org/contrib/qt/qt-5.15.10-static-linux.tar.gz)
 
-## qtbuild.sh (for Unix)
+## qtbuild.sh
+
+For Linux, Mac OS X, Windows MinGW (WIP)
 
 `./qtbuild.sh <VERSION>`
 
 Creates static build of Qt in `/opt/qt-<VERSION>-static`
 
-Supports:
-* Qt5
-* Qt6
-* Linux
-* OSX
-* Windows MinGW (WIP)
-
 `./qtbuild.sh -dynamic <VERSION>`
 
 Creates dynamic build of Qt in `/opt/qt-<VERSION>-dynamic`
 
-Supports:
-* Qt5
-* Qt6
-* Linux
-* OSX
-* Windows MinGW (WIP)
-
-For OSX, use environment variable `QT_BUILD_ARCH` to specify Intel or ARM architecture:
+For OS X, use environment variable `QT_BUILD_ARCH` to specify Intel or ARM architecture:
 
 * Intel: 'x86_64'
 * Arm: 'arm64'
@@ -57,13 +45,15 @@ For OSX, use environment variable `QT_BUILD_ARCH` to specify Intel or ARM archit
 * Universal (Qt6): 'x86_64;arm64'
 
 
-## qtbuild.bat (for Windows MSVC x64)
+## qtbuild.bat
+
+For Microsoft Windows (MSVC)
 
 `qtbuild.bat <VERSION>`
 
 Creates static build of Qt in `c:\qt\qt-<VERSION>-static`
 
-`qtbuild.bat <VERSION>`
+`qtbuild.bat -dynamic <VERSION>`
 
 Creates dynamic build of Qt in `c:\qt\qt-<VERSION>-dynamic`
 

--- a/qtbuild.sh
+++ b/qtbuild.sh
@@ -132,7 +132,7 @@ if [[ ! -d "$QT_SRC_PATH" ]]; then
             # without it, qt builds fail with undefined symbols due to configure only taking first architecture into account
             echo "Patching $QT_SRC_PATH for osx universal builds with qmake"
             patch -d "$QT_SRC_PATH/qtbase" < "./qt5-osx-configure.json.patch"
-        elif [[ $QT_MAJOR_VERSION -eq 6 && $QT_MINOR_VERSION -lt 3 ]]; then
+        elif [[ $QT_MAJOR_VERSION -eq 6 && $QT_MINOR_VERSION -eq 2 && $QT_PATCH_VERSION -lt 5 ]]; then
             # QT6.2.4 on OSX only: this patch fixes a bug in a third-party dependency of WebEngine
             patch -p0 -d "$QT_SRC_PATH" < "./qt6-harfbuzz.patch"
         fi


### PR DESCRIPTION
Don't run dynamic builds unless we are uploading artifacts. This is primarily to control costs for large instance utilization, required to build dynamic qt builds.