### PR TITLE
Adding Qt 6.5.2 builds for Windows

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -99,6 +99,10 @@ jobs:
           runs-on: windows-2019
           qt-version: '6.2.5'
           qt-type: 'static'
+        - name: qt-6.5.2-static-win
+          runs-on: windows-2019
+          qt-version: '6.5.2'
+          qt-type: 'static'
         - name: qt-5.15.10-dynamic-win
           runs-on: windows-2019-8core
           qt-version: '5.15.10'
@@ -106,6 +110,10 @@ jobs:
         - name: qt-6.2.5-dynamic-win
           runs-on: windows-2019-8core
           qt-version: '6.2.5'
+          qt-type: 'dynamic'
+        - name: qt-6.5.2-dynamic-win
+          runs-on: windows-2019-8core
+          qt-version: '6.5.2'
           qt-type: 'dynamic'
     permissions:
       contents: "read"
@@ -206,11 +214,20 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v1'
         with:
           version: '>= 363.0.0'
+      - name: Work-around bug in python 3.11.5
+        if: needs.preflight.outputs.upload_artifact == 'true' && runner.os == 'macOS'
+        shell: bash
+        run: |
+          # temporary work-around for bug in python 3.11.5
+          # see https://github.com/python/cpython/issues/108520
+          brew install python@3.10
+          echo "CLOUDSDK_PYTHON=python3.10" >> $GITHUB_ENV
       - name: Upload build artifact to GCS
         if: needs.preflight.outputs.upload_artifact == 'true'
         shell: bash
         run: |
           # this feature seems to produce permission denied errors on osx and linux runners
+          gcloud version
           gcloud config set storage/parallel_composite_upload_enabled False
           BINFILE="${{ steps.create-binary.outputs.filename }}"
           echo "Uploading $BINFILE to $GCS_UPLOAD_DIR"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Creates dynamic build of Qt in `c:\qt\qt-<VERSION>-dynamic`
 
 ### Before you build...
 
+_Ensure that you checkout this repository in a path that is close to your drive's top-level
+directory. Otherwise, you will run into obscure errors due to Windows path size limitations!_
+
 Install Visual Studio (from [here](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=cs-vs-community%2Ccpp-vs-community%2Cvs-2022-17-1-a%2Cvs-2022-17-1-b)):
 
 ```
@@ -79,7 +82,7 @@ Install some tasty packages (meson 1.2.0 is broken):
 
 ```
 choco install -y meson --version 1.1.1
-choco install -y git jom zip unzip cmake ninja pkgconfiglite winflexbison3 gperf nodejs-lts python2 nasm StrawberryPerl
+choco install -y git jom zip unzip cmake ninja pkgconfiglite winflexbison3 gperf nodejs-lts python nasm StrawberryPerl
 ```
 
 Go to Windows Search, type "Envir" and choose "Edit the system environment variables"
@@ -98,6 +101,11 @@ C:\Program Files\NASM
 Install html5lib (required for 6.2.5+):
 ```
 pip3 install html5lib
+```
+
+Install importlib-metadata (required for WebEngine in 6.5+):
+```
+pip3 install importlib-metadata
 ```
 
 Load Visual Studio paths ([from here](https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-160)):

--- a/qtbuild.sh
+++ b/qtbuild.sh
@@ -72,7 +72,7 @@ fi
 # preferred build settings for various versions and OS
 QT5_FEATURE_OPTIONS="-no-feature-cups -no-feature-ocsp -no-feature-sqlmodel -no-sql-psql -no-feature-linguist -no-feature-pdf -no-feature-printer -no-feature-printdialog -no-feature-printpreviewdialog -no-feature-printpreviewwidget"
 QT5_SKIP_OPTIONS="-skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtcoap -skip qtdatavis3d -skip qtdoc -skip qtgamepad -skip qtimageformats -skip qtlocation -skip qtlottie -skip qtmqtt -skip qtmultimedia -skip qtopcua -skip qtpurchasing -skip qtquick3d -skip qtquicktimeline -skip qtscxml -skip qtremoteobjects -skip qtscript -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qttranslations -skip qtvirtualkeyboard -skip qtwebglplugin -skip qtxmlpatterns"
-QT6_FEATURE_OPTIONS="-no-feature-qtpdf-build -no-feature-qtpdf-quick-build -no-feature-qtpdf-widgets-build -no-feature-printsupport -webengine-proprietary-codecs"
+QT6_FEATURE_OPTIONS="-no-feature-qtpdf-build -no-feature-qtpdf-quick-build -no-feature-qtpdf-widgets-build -no-feature-printsupport"
 QT6_SKIP_OPTIONS="-skip qtgrpc -skip qtlanguageserver -skip qtquick3dphysics"
 QT_CONFIGURE_OPTIONS="-release -optimize-size -no-pch -nomake tools -nomake tests -nomake examples -opensource -confirm-license -feature-appstore-compliant"
 QT_LINUX_OPTIONS="-qt-zlib -qt-libpng -qt-libjpeg -system-freetype -fontconfig -qt-pcre -qt-harfbuzz -no-icu -opengl desktop"


### PR DESCRIPTION
Disabling proprietary codecs for OSX and Linux, since the ones we need are already provided by the operating systems

Fixed gcloud crashes when uploading artifacts on OSX