### PR TITLE
Adding patch to fix chromium webrtc support for h264

### DIFF
--- a/patches/qt-win-webengine-h264.patch
+++ b/patches/qt-win-webengine-h264.patch
@@ -1,0 +1,11 @@
+--- a/qtwebengine/src/3rdparty/chromium/third_party/webrtc/webrtc.gni     2023-09-28 16:19:25.269453200 -0700
++++ b/qtwebengine/src/3rdparty/chromium/third_party/webrtc/webrtc.gni     2023-09-28 16:22:05.654520200 -0700
+@@ -179,7 +179,7 @@
+   # Enabling H264 when building with MSVC is currently not supported, see
+   # bugs.webrtc.org/9213#c13 for more info.
+   rtc_use_h264 =
+-      proprietary_codecs && !is_android && !is_ios && !(is_win && !is_clang)
++      proprietary_codecs && !is_android && !is_ios
+
+   # Enable this flag to make webrtc::Mutex be implemented by absl::Mutex.
+   rtc_use_absl_mutex = false

--- a/qtbuild.bat
+++ b/qtbuild.bat
@@ -73,8 +73,8 @@ if %ERRORLEVEL% EQU 0 Set HAVE_JOM=1
 Set OS=windows
 Set QT5_FEATURE_OPTIONS=-no-feature-cups -no-feature-ocsp -no-feature-sqlmodel -no-sql-psql -no-feature-linguist -no-feature-pdf -no-feature-printer -no-feature-printdialog -no-feature-printpreviewdialog -no-feature-printpreviewwidget
 Set QT5_SKIP_OPTIONS=-skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtcoap -skip qtdatavis3d -skip qtdoc -skip qtgamepad -skip qtimageformats -skip qtlocation -skip qtlottie -skip qtmqtt -skip qtmultimedia -skip qtopcua -skip qtpurchasing -skip qtquick3d -skip qtquicktimeline -skip qtscxml -skip qtremoteobjects -skip qtscript -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qttranslations -skip qtvirtualkeyboard -skip qtwebglplugin -skip qtxmlpatterns
-Set QT6_FEATURE_OPTIONS=-no-feature-qtpdf-build -no-feature-qtpdf-quick-build -no-feature-qtpdf-widgets-build -no-feature-printsupport -webengine-proprietary-codecs
-Set QT6_SKIP_OPTIONS=-skip qtgrpc -skip qtlanguageserver -skip qtquick3dphysics
+Set QT6_FEATURE_OPTIONS=-no-feature-qtpdf-build -no-feature-qtpdf-quick-build -no-feature-qtpdf-widgets-build -no-feature-printsupport
+Set QT6_SKIP_OPTIONS=-skip qtgrpc -skip qtlanguageserver -skip qtquick3dphysics -skip qtgraphs
 Set QT_CONFIGURE_OPTIONS=-release -optimize-size -no-pch -nomake tools -nomake tests -nomake examples -opensource -confirm-license -feature-appstore-compliant
 Set QT_WINDOWS_OPTIONS=-platform win32-msvc -schannel -no-openssl
 Set QT_BUILD_PATH=c:\qt\qt-%QT_FULL_VERSION%
@@ -123,6 +123,8 @@ if NOT exist %QT_SRC_PATH%\ (
     Set QT_SRC_URL=https://download.qt.io/archive/qt/%QT_MAJOR_VERSION%.%QT_MINOR_VERSION%/%QT_FULL_VERSION%/single/!QT_ARCHIVE_BASE_NAME!src-%QT_FULL_VERSION%.zip
     curl -L !QT_SRC_URL! -o qt.zip
     unzip -q qt.zip
+    :: patch to fix h264 support in chromium
+    patch --verbose -u -p 1 -d %QT_SRC_PATH% < patches\qt-win-webengine-h264.patch
 )
 
 :: prepare qt build target

--- a/qtbuild.sh
+++ b/qtbuild.sh
@@ -76,21 +76,21 @@ QT6_FEATURE_OPTIONS="-no-feature-qtpdf-build -no-feature-qtpdf-quick-build -no-f
 QT6_SKIP_OPTIONS="-skip qtgrpc -skip qtlanguageserver -skip qtquick3dphysics"
 QT_CONFIGURE_OPTIONS="-release -optimize-size -no-pch -nomake tools -nomake tests -nomake examples -opensource -confirm-license -feature-appstore-compliant"
 QT_LINUX_OPTIONS="-qt-zlib -qt-libpng -qt-libjpeg -system-freetype -fontconfig -qt-pcre -qt-harfbuzz -no-icu -opengl desktop"
-QT_WINDOWS_OPTIONS="-opengl desktop -platform win32-msvc"
+QT_WINDOWS_OPTIONS="-opengl desktop -platform win32-g++ -schannel -no-openssl"
 MAKE_OPTIONS="-j4"
 CMAKE_OPTIONS="--parallel"
 
 QT_BUILD_PATH=/opt/qt-${QT_FULL_VERSION}
 OPENSSL_BUILD_PATH="/opt/openssl-${OPENSSL_FULL_VERSION}"
 if [[ "$OS" == "windows" ]]; then
-    QT_BUILD_PATH="C:/qt/${QT_FULL_VERSION}"
+    QT_BUILD_PATH="C:/qt/qt-${QT_FULL_VERSION}"
 fi
 
 if [[ $QT_DYNAMIC_BUILD -eq 1 ]]; then
     echo "Building dynamic qt-$QT_FULL_VERSION on $OS"
     QT_BUILD_PATH="$QT_BUILD_PATH-dynamic"
     QT_LINUX_OPTIONS="-openssl-runtime $QT_LINUX_OPTIONS"
-    QT_WINDOWS_OPTIONS="-openssl-linked $QT_WINDOWS_OPTIONS"
+    QT_WINDOWS_OPTIONS="-webengine-proprietary-codecs $QT_WINDOWS_OPTIONS"
     echo "Please ensure you meet the requirements for building QtWebEngine!"
     echo "See https://doc.qt.io/qt-$QT_MAJOR_VERSION/qtwebengine-platform-notes.html"
 else
@@ -98,7 +98,7 @@ else
     QT_BUILD_PATH="$QT_BUILD_PATH-static"
     QT_CONFIGURE_OPTIONS="-static $QT_CONFIGURE_OPTIONS"
     QT_LINUX_OPTIONS="-openssl-linked $QT_LINUX_OPTIONS"
-    QT_WINDOWS_OPTIONS="-static-runtime -openssl-linked $QT_WINDOWS_OPTIONS"
+    QT_WINDOWS_OPTIONS="-static-runtime $QT_WINDOWS_OPTIONS"
     QT5_SKIP_OPTIONS="$QT5_SKIP_OPTIONS -skip qtwebengine"
 fi
 
@@ -279,14 +279,10 @@ fi
 if [[ "$OS" == "windows" ]]; then
     if [[ $QT_MAJOR_VERSION -eq 5 ]]; then
         QT_WINDOWS_OPTIONS="$QT_WINDOWS_OPTIONS -no-feature-d3d12"
-        echo "QT Configure command"
-        echo "\"$QT_SRC_PATH/configure.bat\" -prefix \"$QT_BUILD_PATH\" $QT_WINDOWS_OPTIONS $QT_CONFIGURE_OPTIONS -L \"$QT_BUILD_PATH/lib\" -I \"$QT_BUILD_PATH/include\" OPENSSL_LIBS=\"-llibssl -llibcrypto -lcrypt32 -lws2_32\""
-        "$QT_SRC_PATH/configure.bat" -prefix "$QT_BUILD_PATH" $QT_WINDOWS_OPTIONS $QT_CONFIGURE_OPTIONS -L "$QT_BUILD_PATH/lib" -I "$QT_BUILD_PATH/include" OPENSSL_LIBS="-llibssl -llibcrypto -lcrypt32 -lws2_32"
-    else
-        echo "QT Configure command"
-        echo "\"$QT_SRC_PATH/configure.bat\" -prefix \"$QT_BUILD_PATH\" $QT_WINDOWS_OPTIONS $QT_CONFIGURE_OPTIONS -L \"$QT_BUILD_PATH/lib\" -I \"$QT_BUILD_PATH/include\" OPENSSL_ROOT_DIR=\"$QT_BUILD_PATH\" OPENSSL_LIBS=\"-llibssl -llibcrypto -lcrypt32 -lws2_32\""
-        "$QT_SRC_PATH/configure.bat" -prefix "$QT_BUILD_PATH" $QT_WINDOWS_OPTIONS $QT_CONFIGURE_OPTIONS -L "$QT_BUILD_PATH/lib" -I "$QT_BUILD_PATH/include" OPENSSL_ROOT_DIR="$QT_BUILD_PATH" OPENSSL_LIBS="-llibssl -llibcrypto -lcrypt32 -lws2_32"
     fi
+    echo "QT Configure command"
+    echo "\"$QT_SRC_PATH/configure.bat\" -prefix \"$QT_BUILD_PATH\" $QT_WINDOWS_OPTIONS $QT_CONFIGURE_OPTIONS"
+    "$QT_SRC_PATH/configure.bat" -prefix "$QT_BUILD_PATH" $QT_WINDOWS_OPTIONS $QT_CONFIGURE_OPTIONS
 fi
 
 if [[ $QT_MAJOR_VERSION -eq 5 ]]; then


### PR DESCRIPTION
Without this -webengine-proprietary-codecs is broken. See https://bugreports.qt.io/browse/QTBUG-117478

Add extra skip for qt 6.6.0 compatability

Also updates for qtbuild.sh using g++, although I learned WebEngine doesn't seem to build without MSVC (disabled by configure)