### PR TITLE
Update to qt 6.8.1

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -59,18 +59,42 @@ jobs:
       fail-fast: false # don't abort if one of the build failse
       matrix:
         include:
-        - name: qt-6.5.3-static-linux-amd64
+        - name: qt-6.8.1-static-linux-amd64
           runs-on: ubuntu-22.04
-          qt-version: '6.5.3'
+          qt-version: '6.8.1'
           qt-type: 'static'
           qt-arch: 'linux/amd64'
           is-free: true
-        - name: qt-6.5.3-static-linux-arm64
+        - name: qt-6.8.1-static-linux-arm64
           runs-on: ubuntu-22.04
-          qt-version: '6.5.3'
+          qt-version: '6.8.1'
           qt-type: 'static'
           qt-arch: 'linux/arm64'
           is-free: true
+        - name: qt-6.8.1-static-osx
+          runs-on: macos-14
+          qt-version: '6.8.1'
+          qt-type: 'static'
+          qt-arch: 'x86_64;arm64'
+          is-free: true
+          xcode-directory: /Applications/Xcode_16.2.app
+        - name: qt-6.8.1-dynamic-osx
+          runs-on: macos-14-large
+          qt-version: '6.8.1'
+          qt-type: 'dynamic'
+          qt-arch: 'x86_64;arm64'
+          is-free: false
+          xcode-directory: /Applications/Xcode_16.2.app
+        - name: qt-6.8.1-static-win
+          runs-on: windows-2022
+          qt-version: '6.8.1'
+          qt-type: 'static'
+          is-free: true
+        - name: qt-6.8.1-dynamic-win
+          runs-on: windows-2022-amd64-8core
+          qt-version: '6.8.1'
+          qt-type: 'dynamic'
+          is-free: false
     permissions:
       contents: "read"
       id-token: "write"
@@ -168,6 +192,7 @@ jobs:
             BINFILE="${{ matrix.name }}-${{ needs.preflight.outputs.commit }}.zip"
             7z a "$GITHUB_WORKSPACE/$BINFILE" -tzip $BASENAME
           elif [[ "${{ runner.os }}" == "Linux" ]]; then
+            EXT="tar.gz"
             BINFILE="${{ matrix.name }}-${{ needs.preflight.outputs.commit }}.tar.gz"
             mv "qt-${{ matrix.qt-version }}-${{ matrix.qt-type }}.tar.gz" "$GITHUB_WORKSPACE/$BINFILE"
           else

--- a/README.md
+++ b/README.md
@@ -10,20 +10,26 @@ Projects that use these artifacts must adhere to the terms & conditions of the [
 ## Download Links
 
 Mac OS X (Universal)
-* [Qt 6.2.8 Dynamic](https://files.jacktrip.org/contrib/qt/qt-6.2.8-dynamic-osx.tar.gz)
-* [Qt 6.2.8 Static](https://files.jacktrip.org/contrib/qt/qt-6.2.8-static-osx.tar.gz)
+* [Qt 6.8.1 Dynamic](https://files.jacktrip.org/contrib/qt/qt-6.8.1-dynamic-osx.tar.gz)
+* [Qt 6.8.1 Static](https://files.jacktrip.org/contrib/qt/qt-6.8.1-static-osx.tar.gz)
+* [Qt 6.2.6 Dynamic](https://files.jacktrip.org/contrib/qt/qt-6.2.6-dynamic-osx.tar.gz)
+* [Qt 6.2.6 Static](https://files.jacktrip.org/contrib/qt/qt-6.2.6-static-osx.tar.gz)
 * [Qt 5.15.13 Static](https://files.jacktrip.org/contrib/qt/qt-5.15.13-static-osx.tar.gz)
 
 Windows MSVC (64-bit)
+* [Qt 6.8.1 Dynamic](https://files.jacktrip.org/contrib/qt/qt-6.8.1-dynamic-win.zip)
+* [Qt 6.8.1 Static](https://files.jacktrip.org/contrib/qt/qt-6.8.1-static-win.zip)
 * [Qt 6.5.3 Dynamic](https://files.jacktrip.org/contrib/qt/qt-6.5.3-dynamic-win.zip)
 * [Qt 6.5.3 Static](https://files.jacktrip.org/contrib/qt/qt-6.5.3-static-win.zip)
 * [Qt 5.15.13 Static](https://files.jacktrip.org/contrib/qt/qt-5.15.13-static-win.zip)
 
 Linux (AMD64)
+* [Qt 6.8.1 Static](https://files.jacktrip.org/contrib/qt/qt-6.8.1-static-linux-amd64.tar.gz)
 * [Qt 6.5.3 Static](https://files.jacktrip.org/contrib/qt/qt-6.5.3-static-linux-amd64.tar.gz)
 * [Qt 5.15.13 Static](https://files.jacktrip.org/contrib/qt/qt-5.15.13-static-linux-amd64.tar.gz)
 
 Linux (ARM64)
+* [Qt 6.8.1 Static](https://files.jacktrip.org/contrib/qt/qt-6.8.1-static-linux-arm64.tar.gz)
 * [Qt 6.5.3 Static](https://files.jacktrip.org/contrib/qt/qt-6.5.3-static-linux-arm64.tar.gz)
 * [Qt 5.15.13 Static](https://files.jacktrip.org/contrib/qt/qt-5.15.13-static-linux-arm64.tar.gz)
 
@@ -34,12 +40,12 @@ To build for Linux using Docker:
 
 amd64:
 ```
-docker buildx build --platform linux/amd64 --target=artifact --output type=local,dest=./ --build-arg .
+docker buildx build --platform linux/amd64 --target=artifact --output type=local,dest=./ --build-arg QT_VERSION=6.8.1 .
 ```
 
 arm64
 ```
-docker buildx build --platform linux/arm64 --target=artifact --output type=local,dest=./ --build-arg .
+docker buildx build --platform linux/arm64 --target=artifact --output type=local,dest=./ --build-arg QT_VERSION=6.8.1 .
 ```
 
 arm32:

--- a/qtbuild.sh
+++ b/qtbuild.sh
@@ -220,6 +220,19 @@ if [[ $QT_DYNAMIC_BUILD -ne 1 && "$OS" != "osx" ]]; then
     cp -r $OPENSSL_BUILD_PATH/include/openssl $QT_BUILD_PATH/include
 fi
 
+if [[ $QT_MAJOR_VERSION -eq 6 && $QT_MINOR_VERSION -gt 6 ]]; then
+    # exclude qtgraphs
+    QT_CONFIGURE_OPTIONS="$QT_CONFIGURE_OPTIONS -skip qtgraphs"
+    # include linguist
+    QT_CONFIGURE_OPTIONS=$(echo $QT_CONFIGURE_OPTIONS | sed "s,-no-feature-linguist,,")
+    # linguist also seems to fail if cups (or pdf) are disabled
+    # possibly same as https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=271111
+    #QT_CONFIGURE_OPTIONS=$(echo $QT_CONFIGURE_OPTIONS | sed "s,-no-feature-cups,,")
+    QT_CONFIGURE_OPTIONS=$(echo $QT_CONFIGURE_OPTIONS | sed "s,-no-feature-pdf -no-feature-printer -no-feature-printdialog -no-feature-printpreviewdialog -no-feature-printpreviewwidget,-feature-pdf -feature-printer,")
+    QT_CONFIGURE_OPTIONS=$(echo $QT_CONFIGURE_OPTIONS | sed "s,-no-feature-qtpdf-build,,")
+    QT_CONFIGURE_OPTIONS=$(echo $QT_CONFIGURE_OPTIONS | sed "s,-no-feature-printsupport,,")
+fi
+
 # Linux
 if [[ "$OS" == "linux" ]]; then
     if [[ $QT_MAJOR_VERSION -eq 5 ]]; then


### PR DESCRIPTION
Update to qt 6.8.1 builds

Adding windows and osx static and dynamic builds back in

Enable support for linguist, which is required by some projects