### PR TITLE
Explicitly set CMAKE_OSX_SYSROOT for osx builds

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -120,11 +120,11 @@ jobs:
           if [[ -n "${{ matrix.xcode-directory }}" ]]; then
             sudo xcode-select -s ${{ matrix.xcode-directory }}
           fi
-      - name: OSX - setup python
+      - name: Setup python 3.11
         # OSX runners try to use python 3.12 which fails to build webengine
         # See https://bugs.launchpad.net/ubuntu/+source/qtwebengine-opensource-src/+bug/2058117
         # Also https://bugreports.qt.io/browse/QTBUG-124576
-        if: runner.os == 'macOS' && (needs.preflight.outputs.upload_artifact == 'true' || matrix.is-free)
+        if: (runner.os == 'macOS' || runner.os == 'Windows') && (needs.preflight.outputs.upload_artifact == 'true' || matrix.is-free)
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -132,7 +132,7 @@ jobs:
         if: runner.os == 'Windows' && (needs.preflight.outputs.upload_artifact == 'true' || matrix.is-free)
         shell: bash
         run: |
-          choco install pkgconfiglite winflexbison3 gperf nodejs-lts python2 python311 nasm StrawberryPerl --no-progress
+          choco install pkgconfiglite winflexbison3 gperf nodejs-lts python2 nasm StrawberryPerl --no-progress
           echo "c:\Program Files\NASM" >> $GITHUB_PATH
       - name: Windows - setup MSVC
         uses: ilammy/msvc-dev-cmd@v1
@@ -140,6 +140,7 @@ jobs:
       - name: Install python dependencies
         if: runner.os != 'Linux' && (needs.preflight.outputs.upload_artifact == 'true' || matrix.is-free)
         run: |
+          python3 --version
           pip3 install html5lib
       - name: Linux - Log in to Docker Hub
         if: runner.os == 'Linux' && (needs.preflight.outputs.upload_artifact == 'true' || matrix.is-free)

--- a/patches/qt-6.8.x-webengine-gn-osx-sysroot.patch
+++ b/patches/qt-6.8.x-webengine-gn-osx-sysroot.patch
@@ -1,0 +1,10 @@
+--- a/qtwebengine/cmake/Functions.cmake
++++ b/qtwebengine/cmake/Functions.cmake
+@@ -1467,6 +1467,7 @@ macro(qt_webengine_externalproject_add)
+                    -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+                    -DCMAKE_PREFIX_PATH:PATH=<INSTALL_DIR>
+                    -DCMAKE_OSX_ARCHITECTURES=${OSX_ARCH_STR}
++                   -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}
+                    -DWEBENGINE_ROOT_BUILD_DIR=${PROJECT_BINARY_DIR}
+                    -DQT_ALLOW_SYMLINK_IN_PATHS=${QT_ALLOW_SYMLINK_IN_PATHS}
+     )

--- a/qtbuild.sh
+++ b/qtbuild.sh
@@ -135,6 +135,11 @@ if [[ ! -d "$QT_SRC_PATH" ]]; then
             # without it, qt builds fail with undefined symbols due to configure only taking first architecture into account
             echo "Patching $QT_SRC_PATH for osx universal builds with qmake"
             patch -d "$QT_SRC_PATH/qtbase" < "./patches/qt5-osx-configure.json.patch"
+        elif [[ $QT_MAJOR_VERSION -eq 6 && $QT_MINOR_VERSION -ge 8 ]]; then
+            # QT6.8.x+ on OSX only: fix gn ExternalProject_Add missing CMAKE_OSX_SYSROOT,
+            # which caused gen.py to be invoked with --isysroot but no value
+            echo "Patching $QT_SRC_PATH for webengine gn osx sysroot"
+            patch -p1 -d "$QT_SRC_PATH" < "./patches/qt-6.8.x-webengine-gn-osx-sysroot.patch"
         elif [[ $QT_MAJOR_VERSION -eq 6 && $QT_MINOR_VERSION -eq 2 ]]; then
             if [[ $QT_PATCH_VERSION -eq 4 ]]; then
                 # QT6.2.4 on OSX only: this patch fixes a bug in a third-party dependency of WebEngine
@@ -307,14 +312,15 @@ if [[ "$OS" == "osx" ]]; then
             QT_CONFIGURE_OPTIONS=$(echo $QT_CONFIGURE_OPTIONS | sed "s,-no-feature-printsupport,,")
         fi
         # configure qt for osx
+        CMAKE_OSX_SYSROOT=`xcrun --sdk macosx --show-sdk-path`
         if [[ "x$QT_BUILD_ARCH" == "x" ]]; then
             echo "QT Configure command (NOT universal)"
-            echo "\"$QT_SRC_PATH/configure\" -prefix \"$QT_BUILD_PATH\" $QT_CONFIGURE_OPTIONS"
-            "$QT_SRC_PATH/configure" -prefix "$QT_BUILD_PATH" $QT_CONFIGURE_OPTIONS
+            echo "\"$QT_SRC_PATH/configure\" -prefix \"$QT_BUILD_PATH\" $QT_CONFIGURE_OPTIONS -- \"-DCMAKE_OSX_SYSROOT=$CMAKE_OSX_SYSROOT\""
+            "$QT_SRC_PATH/configure" -prefix "$QT_BUILD_PATH" $QT_CONFIGURE_OPTIONS -- "-DCMAKE_OSX_SYSROOT=$CMAKE_OSX_SYSROOT"
         else
             echo "QT Configure command (universal)"
-            echo "\"$QT_SRC_PATH/configure\" -prefix \"$QT_BUILD_PATH\" $QT_CONFIGURE_OPTIONS -- \"-DCMAKE_OSX_ARCHITECTURES=$QT_BUILD_ARCH\""
-            "$QT_SRC_PATH/configure" -prefix "$QT_BUILD_PATH" $QT_CONFIGURE_OPTIONS -- "-DCMAKE_OSX_ARCHITECTURES=$QT_BUILD_ARCH"
+            echo "\"$QT_SRC_PATH/configure\" -prefix \"$QT_BUILD_PATH\" $QT_CONFIGURE_OPTIONS -- \"-DCMAKE_OSX_ARCHITECTURES=$QT_BUILD_ARCH\" \"-DCMAKE_OSX_SYSROOT=$CMAKE_OSX_SYSROOT\""
+            "$QT_SRC_PATH/configure" -prefix "$QT_BUILD_PATH" $QT_CONFIGURE_OPTIONS -- "-DCMAKE_OSX_ARCHITECTURES=$QT_BUILD_ARCH" "-DCMAKE_OSX_SYSROOT=$CMAKE_OSX_SYSROOT"
         fi
     fi
 fi


### PR DESCRIPTION
Newer cmake fails to generate valid ninja.build files without this

Use actions/setup-python to install 3.11 on Windows, not just OSX